### PR TITLE
Modernize opt-in check; fix socket unit dependencies

### DIFF
--- a/swupd-probe.path
+++ b/swupd-probe.path
@@ -1,6 +1,6 @@
 [Unit]
 Description=swupd telemetry probe
-ConditionPathExists=!/etc/telemetrics/opt-out
+ConditionPathExists=/etc/telemetrics/opt-in
 Requires=telemd.socket
 After=telemd.socket
 

--- a/swupd-probe.path
+++ b/swupd-probe.path
@@ -1,8 +1,8 @@
 [Unit]
 Description=swupd telemetry probe
 ConditionPathExists=/etc/telemetrics/opt-in
-Requires=telemd.socket
-After=telemd.socket
+Requires=telemprobd.socket
+After=telemprobd.socket
 
 [Path]
 DirectoryNotEmpty=/var/lib/swupd/telemetry

--- a/swupd-probe.service
+++ b/swupd-probe.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=swupd telemetry probe
-ConditionPathExists=!/etc/telemetrics/opt-out
+ConditionPathExists=/etc/telemetrics/opt-in
 
 [Service]
 Type=simple


### PR DESCRIPTION
The presence of `/etc/telemetrics/opt-in` is the current method of checking the opt-in selection, rather than the absence of
`/etc/telemetrics/opt-out`.

For reference: https://github.com/clearlinux/telemetrics-client/pull/158

Also fix the socket unit dependencies in `swupd-probe.path` after `telemd` was split into two services. Fixes #3 

@alexjch 